### PR TITLE
Fix tag format for the release-on-tag workflow

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -3,7 +3,7 @@ name: Release on Tag
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:


### PR DESCRIPTION
Currently the workflow won’t run because it expects `v\d+.\d+.\d+`, while the actual tag format is just `\d+.\d+.\d+`.